### PR TITLE
Prefix latest posts links with site url 

### DIFF
--- a/home.hbs
+++ b/home.hbs
@@ -5,7 +5,7 @@
         <section class="gh-topic gh-topic-grid">
             <h2 class="gh-topic-name">
                 {{#match pagination.pages ">" 1}}
-                    <a href="/page/2">Latest</a>
+                    <a href="{{@site.url}}/page/2">Latest</a>
                 {{else}}
                     Latest
                 {{/match}}
@@ -21,7 +21,7 @@
 
             <footer class="gh-topic-footer">
                 {{#match pagination.pages ">" 1}}
-                    <a class="gh-topic-link" href="/page/2">Show more {{> "icons/arrow"}}</a>
+                    <a class="gh-topic-link" href="{{@site.url}}/page/2">Show more {{> "icons/arrow"}}</a>
                 {{/match}}
             </footer>
         </section>


### PR DESCRIPTION
If you are using Ghost with a site url other than the domain's root the links for the latest posts on the home page would not work. 

This PR prefixes the latest post links with the site url.