### PR TITLE
Fix for post per page in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "ghost-theme"
     ],
     "config": {
-        "posts_per_page": 10,
+        "posts_per_page": 7,
         "image_sizes": {
             "xs": {
                 "width": 150


### PR DESCRIPTION
Headline was designed to show 7 posts on the home page, but the package.json file is set to show 10. Because of this, the theme will still only show 7 posts, but will not show the "Show more" button until more than 10 posts are published.