### PR TITLE
refactor author output on loop-grid

### DIFF
--- a/partials/loop-grid.hbs
+++ b/partials/loop-grid.hbs
@@ -31,7 +31,7 @@
             {{/if}}
 
             <footer class="gh-card-footer">
-                <span class="gh-card-author">By {{#foreach authors}}{{name}}{{/foreach}}</span>
+                <span class="gh-card-author">By {{#foreach authors}}{{#if @first}}{{name}}{{else}}, {{name}}{{/if}}{{/foreach}}</span>
                 <span class="gh-card-footer-sep"></span>
                 <time class="gh-card-date" datetime="{{date format="YYYY-MM-DD"}}">{{date}}</time>
             </footer>


### PR DESCRIPTION
Add space to author names on `loop-grid.hbs` 

Ref #11 